### PR TITLE
Turns tempdir LLM argument into a configvar

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,6 +15,10 @@
         "STDIO_MODE_ONLY": {
             "description": "Only allow tool requests via STDIO mode?",
             "value": "false"
+        },
+        "USE_TEMP_DIR": {
+           "description": "Run Python code in a temporary virtualenv (not a sandbox, but does isolate packages).",
+            "value": "false"
         }
     },
     "formation": [

--- a/example_clients/test_sse.py
+++ b/example_clients/test_sse.py
@@ -32,7 +32,7 @@ def mcp(method_name, args=None):
 
     Examples:
         python example_clients/test_sse.py mcp list_tools
-        python example_clients/test_sse.py mcp call_tool --args '{"name": "fetch_webpage_and_markdownify", "arguments": {"url": "https://example.com"}}'
+        python example_clients/test_sse.py mcp call_tool --args '{"name": "code_exec_python", "arguments": {"code": "print(list(range(100)))"}}'
     """
     result = asyncio.run(run(method_name, args))
     print(json.dumps(result.model_dump(), indent=2))

--- a/src/code_execution.py
+++ b/src/code_execution.py
@@ -5,6 +5,8 @@ import tempfile
 from pydantic import Field
 from typing import Annotated
 from typing import Optional, Dict, Any, List, Dict, Any
+# local:
+from src import config
 
 def run_command(cmd: List[str]) -> Dict[str, Any]:
     """Executes a command using subprocess and returns output and errors."""
@@ -83,11 +85,7 @@ def code_exec_python(
     packages: Annotated[
         Optional[List[str]],
         Field(description="Optional list of pip package names to install before execution.")
-    ] = None,
-    use_temp_dir: Annotated[
-        bool,
-        Field(description="Use a temporary isolated virtual environment in a tempdir for this run.")
-    ] = False
+    ] = None
 ) -> Dict[str, Any]:
     """Executes a Python code snippet with optional pip dependencies.
 
@@ -100,7 +98,7 @@ def code_exec_python(
             - 'stdout': Captured standard output.
             - 'stderr': Captured standard error or install failure messages.
     """
-    if use_temp_dir:
+    if config.USE_TEMP_DIR:
         return run_in_tempdir(code, packages)
 
     install_result = install_dependencies(packages)

--- a/src/config.py
+++ b/src/config.py
@@ -17,6 +17,7 @@ def get_env_variable(var_name, required=True):
 PORT = int(os.environ.get('PORT', 8000))
 WEB_CONCURRENCY = int(os.environ.get('WEB_CONCURRENCY', 1))
 STDIO_MODE_ONLY = os.getenv("STDIO_MODE_ONLY", "false").lower() == "true"
+USE_TEMP_DIR = os.getenv("USE_TEMP_DIR", "false").lower() == "true"
 
 # Local or Not:
 is_one_off_dyno = os.getenv("DYNO") is not None


### PR DESCRIPTION
Removes the use_temp_dir arg, turns into a USE_TEMP_DIR configvar (default false for STDIO) - also improves example in the example sse client

https://salesforce-internal.slack.com/archives/C07372EAVJA/p1747182585288399