### PR TITLE
Set `GUSINFO` team and product tag in `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
-#GUSINFO:Open Source,Open Source Workflow
+#GUSINFO:Heroku AI,Heroku AI
 * @heroku/ai


### PR DESCRIPTION
The `#GUSINFO:` line in `CODEOWNERS` uses the placeholder `Open Source,Open Source Workflow` rather than a real team/product tag. This change sets it to `Heroku AI,Heroku AI`.

This correction was suggested by Claude Code, based on the GitHub owner team (`@heroku/ai`) and its active product tag in GUS. The reviewer should confirm the new product tag is correct and the most appropriate one for this component.

[GUS-W-23525396](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002fLLNXYA4/view).